### PR TITLE
when searching for 'eff' - depending on whether we search filter=target

### DIFF
--- a/app/common/elasticsearchclient.py
+++ b/app/common/elasticsearchclient.py
@@ -243,7 +243,7 @@ class esQuery():
         #there are len(params.q) responses - one per query
         for i in range(len(results['responses'])):
             name = params.q[i]  #even though we are guaranteed that responses come back in order, and can match query to the result - this might be convenient to have       
-            #print "name =" + name 
+            print "name =" + name 
             lower_name = name.lower()
             res = results['responses'][i]
             exact_match = False
@@ -253,15 +253,17 @@ class esQuery():
                 fields = kwargs['fields'];
                 if 'highlight' in hit:
                     highlight = hit['highlight']
-                if (lower_name == hit['_id'].lower):
+                
+                id_lower = hit['_id'].lower()
+                type_ = hit['_type']
+                if (lower_name == id_lower):
                     exact_match = True
-                elif 'search-object-target' in doc_filter:
-                    if('approved_symbol' in hit['_source'] and lower_name == hit['_source']['approved_symbol'].lower()):
+                elif (type_ == 'search-object-target' and lower_name == hit['_source']['approved_symbol'].lower()):
                         exact_match = True
-                elif 'search-object-disease' in doc_filter:
-                    if('name' in hit['_source'] and lower_name == hit['_source']['name'].lower()):
+                elif(type_ == 'search-object-disease' and lower_name == hit['_source']['name'].lower()):
                         exact_match = True
-                datapoint = dict(type=hit['_type'],
+                        
+                datapoint = dict(type= type_,
                                  data=hit['_source'],
                                  id=hit['_id'],
                                  score=hit['_score'],

--- a/app/common/elasticsearchclient.py
+++ b/app/common/elasticsearchclient.py
@@ -243,16 +243,24 @@ class esQuery():
         #there are len(params.q) responses - one per query
         for i in range(len(results['responses'])):
             name = params.q[i]  #even though we are guaranteed that responses come back in order, and can match query to the result - this might be convenient to have       
+            #print "name =" + name 
             lower_name = name.lower()
             res = results['responses'][i]
             exact_match = False
             if(res['hits']['total']>0):
                 hit = res['hits']['hits'][0] #expect either 1 result or none
                 highlight = ''
+                fields = kwargs['fields'];
                 if 'highlight' in hit:
                     highlight = hit['highlight']
-                if(lower_name == hit['_source']['approved_symbol'].lower() or lower_name == hit['_id'].lower):
+                if (lower_name == hit['_id'].lower):
                     exact_match = True
+                elif 'search-object-target' in doc_filter:
+                    if('approved_symbol' in hit['_source'] and lower_name == hit['_source']['approved_symbol'].lower()):
+                        exact_match = True
+                elif 'search-object-disease' in doc_filter:
+                    if('name' in hit['_source'] and lower_name == hit['_source']['name'].lower()):
+                        exact_match = True
                 datapoint = dict(type=hit['_type'],
                                  data=hit['_source'],
                                  id=hit['_id'],
@@ -1551,6 +1559,8 @@ ev_score_ds = doc['scores.association_score'].value * %f / %f;
             params.requested_fields = source['include']
             if 'highlight' not in params.requested_fields:
                 highlight = None
+        else:
+            highlight = None
 
         for searchphrase in params.q:
             body = {'query': self._get_free_text_query(searchphrase.lower()),

--- a/app/common/elasticsearchclient.py
+++ b/app/common/elasticsearchclient.py
@@ -245,12 +245,9 @@ class esQuery():
         data = []
         
         #there are len(params.q) responses - one per query
-        #for i in range(len(results['responses'])):
         for i,res in enumerate(results['responses']):
-            name = params.q[i]  #even though we are guaranteed that responses come back in order, and can match query to the result - this might be convenient to have       
-            #print "name =" + name 
-            lower_name = name.lower()
-            #res = results['responses'][i]
+            name = params.q[i]  #even though we are guaranteed that responses come back in order, and can match query to the result - this might be convenient to have                
+            lower_name = name.lower()    
             exact_match = False
             if(res['hits']['total']>0):
                 hit = res['hits']['hits'][0] #expect either 1 result or none

--- a/app/common/elasticsearchclient.py
+++ b/app/common/elasticsearchclient.py
@@ -48,6 +48,10 @@ class FreeTextFilterOptions():
     PUBLICATION = 'pub'
     SNP = 'snp'
     GENERIC = 'generic'
+    
+class SearchObjectTypes():
+    TARGET = 'search-object-target'
+    DISEASE = 'search-object-disease'
 
 
 class ESResultStatus(object):
@@ -241,26 +245,27 @@ class esQuery():
         data = []
         
         #there are len(params.q) responses - one per query
-        for i in range(len(results['responses'])):
+        #for i in range(len(results['responses'])):
+        for i,res in enumerate(results['responses']):
             name = params.q[i]  #even though we are guaranteed that responses come back in order, and can match query to the result - this might be convenient to have       
-            print "name =" + name 
+            #print "name =" + name 
             lower_name = name.lower()
-            res = results['responses'][i]
+            #res = results['responses'][i]
             exact_match = False
             if(res['hits']['total']>0):
                 hit = res['hits']['hits'][0] #expect either 1 result or none
                 highlight = ''
-                fields = kwargs['fields'];
+                fields = kwargs.get('fields', []) or []
                 if 'highlight' in hit:
                     highlight = hit['highlight']
                 
                 id_lower = hit['_id'].lower()
                 type_ = hit['_type']
-                if (lower_name == id_lower):
+                if lower_name == id_lower:
                     exact_match = True
-                elif (type_ == 'search-object-target' and lower_name == hit['_source']['approved_symbol'].lower()):
+                elif type_ == SearchObjectTypes.TARGET and lower_name == hit['_source']['approved_symbol'].lower():
                         exact_match = True
-                elif(type_ == 'search-object-disease' and lower_name == hit['_source']['name'].lower()):
+                elif type_ == SearchObjectTypes.DISEASE and lower_name == hit['_source']['name'].lower():
                         exact_match = True
                         
                 datapoint = dict(type= type_,

--- a/app/resources/freetextsearch.py
+++ b/app/resources/freetextsearch.py
@@ -18,8 +18,8 @@ class FreeTextSearch(restful.Resource, Paginable):
     parser =boilerplate.get_parser()
     parser.add_argument('q', type=str, required=True, help="Query cannot be blank!")
     parser.add_argument('filter', type=str, required=False,  action='append', help="filter by gene or efo")
-    
-    
+
+
     @is_authenticated
     @rate_limit
     def get(self ):
@@ -59,18 +59,18 @@ class BestHitSearch(restful.Resource, Paginable):
         start_time = time.time()
         kwargs = self.parser.parse_args()
         kwargs.pop('size');
-       
-        
-        
+
+
+
         filter_ = kwargs.pop('filter') or ['all']
         if 'target' in filter_:
-            kwargs['fields'] = ['id','approved_symbol'] #do not want any other fields
+            kwargs['fields'] = ['approved_symbol'] #do not want any other fields
         elif 'disease' in filter_:
-            kwargs['fields'] = ['id','name']
+            kwargs['fields'] = ['name']
         res = current_app.extensions['esquery'].best_hit_search( doc_filter=filter_, **kwargs)
         return CTTVResponse.OK(res,
                                    took=time.time() - start_time)
-    
+
     @is_authenticated
     @rate_limit
     def post(self):
@@ -80,7 +80,7 @@ class BestHitSearch(restful.Resource, Paginable):
         """
         start_time = time.time()
         kwargs = request.get_json(force=True)
-        
+
         filter_ = [kwargs.pop('filter')] or ['all']
         if 'target' in filter_:
             kwargs['fields'] = ['approved_symbol']; #do not want any other fields
@@ -89,8 +89,8 @@ class BestHitSearch(restful.Resource, Paginable):
         res = current_app.extensions['esquery'].best_hit_search( doc_filter=filter_, **kwargs)
         return CTTVResponse.OK(res,
                                    took=time.time() - start_time)
-    
-       
+
+
 
 
 
@@ -141,4 +141,3 @@ class AutoComplete(restful.Resource):
             return CTTVResponse.OK(res)
         else:
             abort(400, message = "Query is too short")
-

--- a/app/resources/freetextsearch.py
+++ b/app/resources/freetextsearch.py
@@ -59,9 +59,14 @@ class BestHitSearch(restful.Resource, Paginable):
         start_time = time.time()
         kwargs = self.parser.parse_args()
         kwargs.pop('size');
-        kwargs['fields'] = ['id', 'approved_symbol']; #do not want any other fields
+       
+        
         
         filter = kwargs.pop('filter') or ['all']
+        if 'target' in filter:
+            kwargs['fields'] = ['id','approved_symbol']; #do not want any other fields
+        elif 'disease' in filter:
+            kwargs['fields'] = ['id','name'];
         res = current_app.extensions['esquery'].best_hit_search( doc_filter=filter, **kwargs)
         return CTTVResponse.OK(res,
                                    took=time.time() - start_time)
@@ -76,11 +81,11 @@ class BestHitSearch(restful.Resource, Paginable):
         start_time = time.time()
         kwargs = request.get_json(force=True)
         
-        kwargs['fields'] = ['id', 'approved_symbol']; #do not want any other fields
-        
-        filter = ['all']
-        if ('filter' in kwargs):
-            filter = kwargs['filter']
+        filter = [kwargs.pop('filter')] or ['all']
+        if 'target' in filter:
+            kwargs['fields'] = ['id','approved_symbol']; #do not want any other fields
+        elif 'disease' in filter:
+            kwargs['fields'] = ['id','name'];
         res = current_app.extensions['esquery'].best_hit_search( doc_filter=filter, **kwargs)
         return CTTVResponse.OK(res,
                                    took=time.time() - start_time)

--- a/app/resources/freetextsearch.py
+++ b/app/resources/freetextsearch.py
@@ -83,9 +83,9 @@ class BestHitSearch(restful.Resource, Paginable):
         
         filter = [kwargs.pop('filter')] or ['all']
         if 'target' in filter:
-            kwargs['fields'] = ['id','approved_symbol']; #do not want any other fields
+            kwargs['fields'] = ['approved_symbol']; #do not want any other fields
         elif 'disease' in filter:
-            kwargs['fields'] = ['id','name'];
+            kwargs['fields'] = ['name'];
         res = current_app.extensions['esquery'].best_hit_search( doc_filter=filter, **kwargs)
         return CTTVResponse.OK(res,
                                    took=time.time() - start_time)

--- a/app/resources/freetextsearch.py
+++ b/app/resources/freetextsearch.py
@@ -62,12 +62,12 @@ class BestHitSearch(restful.Resource, Paginable):
        
         
         
-        filter = kwargs.pop('filter') or ['all']
-        if 'target' in filter:
-            kwargs['fields'] = ['id','approved_symbol']; #do not want any other fields
-        elif 'disease' in filter:
-            kwargs['fields'] = ['id','name'];
-        res = current_app.extensions['esquery'].best_hit_search( doc_filter=filter, **kwargs)
+        filter_ = kwargs.pop('filter') or ['all']
+        if 'target' in filter_:
+            kwargs['fields'] = ['id','approved_symbol'] #do not want any other fields
+        elif 'disease' in filter_:
+            kwargs['fields'] = ['id','name']
+        res = current_app.extensions['esquery'].best_hit_search( doc_filter=filter_, **kwargs)
         return CTTVResponse.OK(res,
                                    took=time.time() - start_time)
     
@@ -81,12 +81,12 @@ class BestHitSearch(restful.Resource, Paginable):
         start_time = time.time()
         kwargs = request.get_json(force=True)
         
-        filter = [kwargs.pop('filter')] or ['all']
-        if 'target' in filter:
+        filter_ = [kwargs.pop('filter')] or ['all']
+        if 'target' in filter_:
             kwargs['fields'] = ['approved_symbol']; #do not want any other fields
-        elif 'disease' in filter:
+        elif 'disease' in filter_:
             kwargs['fields'] = ['name'];
-        res = current_app.extensions['esquery'].best_hit_search( doc_filter=filter, **kwargs)
+        res = current_app.extensions['esquery'].best_hit_search( doc_filter=filter_, **kwargs)
         return CTTVResponse.OK(res,
                                    took=time.time() - start_time)
     

--- a/tests/test_freetextsearch.py
+++ b/tests/test_freetextsearch.py
@@ -81,23 +81,83 @@ class FreeTextSearchTestCase(GenericTestCase):
         self.assertEqual(len(first_result), 2)
         self.assertEqual(first_result['approved_symbol'], 'BRAF')
         self.assertEqual(first_result['id'], 'ENSG00000157764')
-
-
-    def testBestHitSearchFields(self):
+        
+    #@unittest.skip("testBestHitSearchFieldsNoFilter")    
+    def testBestHitSearchFieldsNoFilter(self):
         response= self._make_request('/api/latest/private/besthitsearch',
-                                    data={'q':['braf', 'nr3c1', 'Rpl18a', 'rippa', 'ENSG00000157764']},
-     
-                                     token=self._AUTO_GET_TOKEN)
+                                    data={'q':['braf', 'nr3c1', 'Rpl18a', 'rippa', 'ENSG00000157764', 'eff']},                                  
+                                    token=self._AUTO_GET_TOKEN)
 
         self.assertTrue(response.status_code == 200)
         json_response = json.loads(response.data.decode('utf-8'))
         
-        self.assertEqual(len(json_response['data']), 5)
-        
+        self.assertEqual(len(json_response['data']), 6)
+         
         braf_data = json_response['data'][0];
         self.assertEqual( braf_data['highlight'], '')
         self.assertEqual( braf_data['id'], 'ENSG00000157764')
         self.assertEqual(braf_data['q'], 'braf')
+ 
+        first_result_braf =braf_data['data']
+        self.assertNotEqual(len(first_result_braf), 2) #should have more fields since we are not restricting
+        self.assertEqual(first_result_braf['approved_symbol'], 'BRAF')
+        self.assertEqual(first_result_braf['id'], 'ENSG00000157764')
+         
+        nr3c1_data = json_response['data'][1];
+        self.assertEqual( nr3c1_data['highlight'], '')
+        self.assertEqual( nr3c1_data['id'], 'ENSG00000113580')
+         
+        first_result_nr3c1 =nr3c1_data['data']
+        self.assertNotEqual(len(first_result_nr3c1), 2)
+        self.assertEqual(first_result_nr3c1['approved_symbol'], 'NR3C1')
+        self.assertEqual(first_result_nr3c1['id'], 'ENSG00000113580')
+         
+        #test fuzzy result
+        fuzzy_result = json_response['data'][2];
+        self.assertEqual(fuzzy_result['q'], 'Rpl18a')
+        fuzzy_result_data = fuzzy_result['data']
+        self.assertNotEqual(fuzzy_result_data['approved_symbol'], 'RPL18A')
+ 
+        #test empty result
+        empty_result = json_response['data'][3];
+        self.assertEqual(empty_result['q'], 'rippa')
+        self.assertEqual(empty_result['id'], None)
+         
+        #test  when query is ENS ID
+        ens_data = json_response['data'][4];
+        self.assertEqual( ens_data['highlight'], '')
+        self.assertEqual( ens_data['id'], 'ENSG00000157764')
+        self.assertEqual(ens_data['q'], 'ENSG00000157764')
+ 
+        first_result_ens =ens_data['data']
+        self.assertNotEqual(len(first_result_ens), 2)
+        self.assertEqual(first_result_ens['approved_symbol'], 'BRAF')
+        self.assertEqual(first_result_ens['id'], 'ENSG00000157764')
+        
+        #test eff which can be desease or target depending on how search is done
+        eff_data = json_response['data'][5];
+        self.assertEqual(eff_data['q'], 'eff');
+        self.assertEqual(eff_data['exact'], False);
+        self.assertEqual(len(eff_data['data']),15) #no restrictions on returned fields 
+        
+
+    #@unittest.skip(" testBestHitSearchFieldsTarget")
+    def testBestHitSearchFieldsTarget(self):
+        response= self._make_request('/api/latest/private/besthitsearch',
+                                    data={'q':['braf', 'nr3c1', 'Rpl18a', 'rippa', 'ENSG00000157764', 'eff'],
+                                           'filter':'target'},
+                                    token=self._AUTO_GET_TOKEN)
+
+        self.assertTrue(response.status_code == 200)
+        json_response = json.loads(response.data.decode('utf-8'))
+        
+        self.assertEqual(len(json_response['data']),6)
+        
+        braf_data = json_response['data'][0];
+        self.assertEqual( braf_data['highlight'], '')
+        self.assertEqual( braf_data['id'], 'ENSG00000157764')
+        self.assertEqual( braf_data['q'], 'braf')
+        self.assertEqual( braf_data['exact'], True)
 
         first_result_braf =braf_data['data']
         self.assertEqual(len(first_result_braf), 2)
@@ -107,6 +167,7 @@ class FreeTextSearchTestCase(GenericTestCase):
         nr3c1_data = json_response['data'][1];
         self.assertEqual( nr3c1_data['highlight'], '')
         self.assertEqual( nr3c1_data['id'], 'ENSG00000113580')
+        self.assertEqual( nr3c1_data['exact'], True)
         
         first_result_nr3c1 =nr3c1_data['data']
         self.assertEqual(len(first_result_nr3c1), 2)
@@ -134,15 +195,69 @@ class FreeTextSearchTestCase(GenericTestCase):
         self.assertEqual(len(first_result_ens), 2)
         self.assertEqual(first_result_ens['approved_symbol'], 'BRAF')
         self.assertEqual(first_result_ens['id'], 'ENSG00000157764')
+        
+        eff_data = json_response['data'][5];
+        self.assertEqual(eff_data['q'], 'eff');
+        self.assertEqual(eff_data['exact'], False);
+        self.assertEqual(len(eff_data['data']),2) #should only get name and id
+        self.assertEqual(eff_data['data']['approved_symbol'],'UBE2D3')
+          
     
-    #@unittest.skip("testBestHitSearchFieldsPost")    
-    def testBestHitSearchFieldsPost(self):
+        
+    #@unittest.skip(" testBestHitSearchFieldsDisease")
+    def testBestHitSearchFieldsDisease(self):
+        response= self._make_request('/api/latest/private/besthitsearch',
+                                    data={'q':['braf', 'nr3c1', 'Rpl18a', 'rippa', 'ENSG00000157764', 'eff'], 'filter':'disease'},
+                                    token=self._AUTO_GET_TOKEN)
+
+        self.assertTrue(response.status_code == 200)
+        json_response = json.loads(response.data.decode('utf-8'))
+        
+        self.assertEqual(len(json_response['data']), 6)
+        
+        braf_data = json_response['data'][0];#should get nothing for target when searching for diseases
+        self.assertEqual( braf_data['id'], None)
+        self.assertEqual(braf_data['q'], 'braf')
+
+        nr3c1_data = json_response['data'][1]
+        self.assertEqual(nr3c1_data['q'], 'nr3c1')
+        self.assertEqual( nr3c1_data['id'], None)
+        
+        #test fuzzy result
+        fuzzy_result = json_response['data'][2];
+        self.assertEqual(fuzzy_result['q'], 'Rpl18a')
+        self.assertEqual( fuzzy_result['id'], None)
+
+        #test empty result
+        empty_result = json_response['data'][3];
+        self.assertEqual(empty_result['q'], 'rippa') #good there is not a disease with my name! ;-)
+        self.assertEqual(empty_result['id'], None)
+        
+        #test  when query is ENS ID
+        ens_data = json_response['data'][4];
+        
+        self.assertEqual( ens_data['id'], None)
+        self.assertEqual(ens_data['q'], 'ENSG00000157764')
+        
+        #test eff which can be desease or target depending on how search is done
+        eff_data = json_response['data'][5];
+        self.assertEqual(eff_data['q'], 'eff');
+        self.assertEqual(eff_data['exact'], False);
+        self.assertEqual(len(eff_data['data']),2) #should only get name and id
+        self.assertEqual(eff_data['data']['name'],'insulin resistance')
+        self.assertEqual(eff_data['data']['id'],'EFO_0002614')  
+    
+    ##@unittest.skip("testBestHitSearchFieldsPostTarget")    
+    def testBestHitSearchFieldsPostTarget(self):
         
         #passing some dummy fields 'fields':['field1', 'field2'] just to show 
         #that they are going to be overwritten and data will have only two
         # fields: approved_symbol and id
         response= self._make_request('/api/latest/private/besthitsearch',
-                                     data=json.dumps({'q':['braf', 'nr3c1', 'Rpl18a', 'rippa', 'ENSG00000157764'], 'fields':['field1', 'field2']}),
+                                     data=json.dumps({
+                                            'q':['braf', 'nr3c1', 'Rpl18a', 'rippa', 'ENSG00000157764', 'eff'], 
+                                            'fields':['field1', 'field2'], 
+                                            'filter':'target'}),
                                      content_type='application/json',
                                      method='POST',
                                      token=self._AUTO_GET_TOKEN)
@@ -150,11 +265,12 @@ class FreeTextSearchTestCase(GenericTestCase):
         self.assertTrue(response.status_code == 200)
         json_response = json.loads(response.data.decode('utf-8'))
         
-        self.assertEqual(len(json_response['data']), 5)
+        self.assertEqual(len(json_response['data']), 6)
         
         braf_data = json_response['data'][0];
         self.assertEqual( braf_data['highlight'], '')
         self.assertEqual( braf_data['id'], 'ENSG00000157764')
+        self.assertEqual( braf_data['exact'], True)
         
         first_result_braf =braf_data['data']
         self.assertEqual(len(first_result_braf), 2)
@@ -195,6 +311,12 @@ class FreeTextSearchTestCase(GenericTestCase):
         self.assertEqual(len(first_result_ens), 2)
         self.assertEqual(first_result_ens['approved_symbol'], 'BRAF')
         self.assertEqual(first_result_ens['id'], 'ENSG00000157764')
+        
+        eff_data = json_response['data'][5];
+        self.assertEqual(eff_data['q'], 'eff');
+        self.assertEqual(eff_data['exact'], False);
+        self.assertEqual(len(eff_data['data']),2) #should only get name and id
+        self.assertEqual(eff_data['data']['approved_symbol'],'UBE2D3')
         
     #@unittest.skip("testAsthma")
     def testAsthma(self):

--- a/tests/test_freetextsearch.py
+++ b/tests/test_freetextsearch.py
@@ -189,7 +189,8 @@ class FreeTextSearchTestCase(GenericTestCase):
         ens_data = json_response['data'][4];
         self.assertEqual( ens_data['highlight'], '')
         self.assertEqual( ens_data['id'], 'ENSG00000157764')
-        self.assertEqual(ens_data['q'], 'ENSG00000157764')
+        self.assertEqual( ens_data['q'], 'ENSG00000157764')
+        self.assertEqual( ens_data['exact'], True)
 
         first_result_ens =ens_data['data']
         self.assertEqual(len(first_result_ens), 2)
@@ -234,10 +235,9 @@ class FreeTextSearchTestCase(GenericTestCase):
         self.assertEqual(empty_result['id'], None)
         
         #test  when query is ENS ID
-        ens_data = json_response['data'][4];
-        
+        ens_data = json_response['data'][4];   
         self.assertEqual( ens_data['id'], None)
-        self.assertEqual(ens_data['q'], 'ENSG00000157764')
+        self.assertEqual( ens_data['q'], 'ENSG00000157764')
         
         #test eff which can be desease or target depending on how search is done
         eff_data = json_response['data'][5];
@@ -245,7 +245,7 @@ class FreeTextSearchTestCase(GenericTestCase):
         self.assertEqual(eff_data['exact'], False);
         self.assertEqual(len(eff_data['data']),2) #should only get name and id
         self.assertEqual(eff_data['data']['name'],'insulin resistance')
-        self.assertEqual(eff_data['data']['id'],'EFO_0002614')  
+        
     
     ##@unittest.skip("testBestHitSearchFieldsPostTarget")    
     def testBestHitSearchFieldsPostTarget(self):
@@ -273,9 +273,9 @@ class FreeTextSearchTestCase(GenericTestCase):
         self.assertEqual( braf_data['exact'], True)
         
         first_result_braf =braf_data['data']
-        self.assertEqual(len(first_result_braf), 2)
+        self.assertEqual(len(first_result_braf), 1)
         self.assertEqual(first_result_braf['approved_symbol'], 'BRAF')
-        self.assertEqual(first_result_braf['id'], 'ENSG00000157764')
+        
         
         nr3c1_data = json_response['data'][1];
         self.assertEqual( nr3c1_data['highlight'], '')
@@ -283,9 +283,9 @@ class FreeTextSearchTestCase(GenericTestCase):
         self.assertEqual( nr3c1_data['exact'], True)
 
         first_result_nr3c1 =nr3c1_data['data']
-        self.assertEqual(len(first_result_nr3c1), 2)
+        self.assertEqual(len(first_result_nr3c1), 1)
         self.assertEqual(first_result_nr3c1['approved_symbol'], 'NR3C1')
-        self.assertEqual(first_result_nr3c1['id'], 'ENSG00000113580')
+        
         
         #test fuzzy result
         fuzzy_result = json_response['data'][2];
@@ -305,17 +305,18 @@ class FreeTextSearchTestCase(GenericTestCase):
         ens_data = json_response['data'][4];
         self.assertEqual( ens_data['highlight'], '')
         self.assertEqual( ens_data['id'], 'ENSG00000157764')
-        self.assertEqual(ens_data['q'], 'ENSG00000157764')
-
+        self.assertEqual( ens_data['q'], 'ENSG00000157764')
+        self.assertEqual( ens_data['exact'], True)
+        
         first_result_ens =ens_data['data']
-        self.assertEqual(len(first_result_ens), 2)
+        self.assertEqual(len(first_result_ens), 1)
         self.assertEqual(first_result_ens['approved_symbol'], 'BRAF')
-        self.assertEqual(first_result_ens['id'], 'ENSG00000157764')
+    
         
         eff_data = json_response['data'][5];
         self.assertEqual(eff_data['q'], 'eff');
         self.assertEqual(eff_data['exact'], False);
-        self.assertEqual(len(eff_data['data']),2) #should only get name and id
+        self.assertEqual(len(eff_data['data']),1) #should only get name and id
         self.assertEqual(eff_data['data']['approved_symbol'],'UBE2D3')
         
     #@unittest.skip("testAsthma")


### PR DESCRIPTION
or filter=disease or no filter - we should get different results. Also,
search fields that we want to get are limited to id and approved_symbol
for target and is and name for diseases. At least for now. Do not limit
the fields that come back when there is no filter.

@apierleoni @emepyc @elipapa 